### PR TITLE
style: fix add row overlay issue

### DIFF
--- a/resources/css/layup.css
+++ b/resources/css/layup.css
@@ -209,7 +209,6 @@
 /* ── Canvas ── */
 .lyp-canvas {
     flex: 1;
-    overflow: auto;
     background: var(--gray-50);
     padding: 1.5rem;
 }


### PR DESCRIPTION
Hello, 

this PR fix the issue with the overflow for the "add row" overlay when creating new  blank pages, mentioned in [https://github.com/Crumbls/layup/issues/1](https://github.com/Crumbls/layup/issues/1)
