### PR TITLE
Hide "pages" page in filament panel

### DIFF
--- a/config/layup.php
+++ b/config/layup.php
@@ -160,6 +160,7 @@ return [
     'pages' => [
         'table' => 'layup_pages',
         'model' => \Crumbls\Layup\Models\Page::class,
+        'enabled' => true,
         'default_slug' => null,
 
         /*

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,12 +50,14 @@ The filesystem disk used for media uploads (images, files). Must be publicly acc
 'pages' => [
     'table' => 'layup_pages',
     'model' => \Crumbls\Layup\Models\Page::class,
+    'enabled' => true,
     'default_slug' => null,
 ],
 ```
 
 - **table** -- database table name for pages. Change this if you need multiple Layup instances with separate tables.
 - **model** -- the Eloquent model class. Extend `Page` and point here to add custom behavior.
+- **enabled** -- whether the Pages resource is registered in the Filament admin panel. Set to `false` when you're using Layup purely as a rendering engine (e.g. attaching `HasLayupContent` to your own models and managing content through your own Filament resources). Disabling the resource does not affect frontend rendering or the database -- it only removes the admin UI. Pages already in the database still render normally via the frontend controller or `@layup` directive.
 - **default_slug** -- if set, this slug is served when the frontend prefix is hit without a slug.
 
 ## Revisions

--- a/src/LayupPlugin.php
+++ b/src/LayupPlugin.php
@@ -143,9 +143,11 @@ class LayupPlugin implements Plugin
 
     public function register(Panel $panel): void
     {
-        $panel->resources([
-            PageResource::class,
-        ]);
+        if (config('layup.pages.enabled', true)) {
+            $panel->resources([
+                PageResource::class,
+            ]);
+        }
     }
 
     public function boot(Panel $panel): void


### PR DESCRIPTION
This PR allows users to hide the "pages" resource from their admin panels. In some cases (e.g when the user only wants to render the LayupContent from a model) the "pages" resource is not needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pages feature can now be conditionally enabled or disabled via configuration, allowing administrators to control whether the Pages resource appears in the admin panel.

* **Documentation**
  * Updated configuration documentation to explain the new `enabled` option and its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->