### PR TITLE
Built in slugless pages with possible home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,31 @@ Pages support nested slugs via wildcard routing:
 /pages/about/team     → slug: about/team
 ```
 
+### Default Page (Homepage)
+
+By default, hitting the index route (`/pages` or `/` with an empty prefix) looks for a page with an empty slug. To serve a specific page as the homepage instead, set `default_slug` in your config:
+
+```php
+// config/layup.php
+'pages' => [
+    'table' => 'layup_pages',
+    'model' => \Crumbls\Layup\Models\Page::class,
+    'default_slug' => 'home',  // Serve the "home" page at the index route
+],
+```
+
+With this configuration:
+
+| URL | Resolves |
+|-----|----------|
+| `/pages` (or `/` with empty prefix) | Page with slug `home` |
+| `/pages/about` | Page with slug `about` |
+| `/pages/docs/getting-started` | Page with slug `docs/getting-started` |
+
+Set `default_slug` to `null` to use the original behavior (looks for a page with an empty slug).
+
+This works with any prefix configuration -- whether you serve pages at `/pages/{slug}` or directly at `/{slug}` with an empty prefix.
+
 ### Custom Controller
 
 Layup provides a base controller for frontend rendering:
@@ -1016,6 +1041,7 @@ return [
     'pages' => [
         'table' => 'layup_pages',
         'model' => \Crumbls\Layup\Models\Page::class,
+        'default_slug' => null, // Slug to serve at the index route (null = empty slug)
     ],
 
     // Frontend rendering

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -22,8 +22,14 @@ class PageController extends AbstractController
     {
         $modelClass = config('layup.pages.model', Page::class);
 
+        $slug = $request->route('slug', '');
+
+        if ($slug === '' || $slug === null) {
+            $slug = config('layup.pages.default_slug') ?? '';
+        }
+
         return $modelClass::query()
-            ->where('slug', $request->route('slug', ''))
+            ->where('slug', $slug)
             ->published()
             ->firstOrFail();
     }

--- a/src/LayupPlugin.php
+++ b/src/LayupPlugin.php
@@ -46,6 +46,7 @@ class LayupPlugin implements Plugin
      */
     public function widgets(array $widgets): static
     {
+
         $this->extraWidgets = array_merge($this->extraWidgets, $widgets);
 
         return $this;

--- a/tests/Feature/DefaultPageTest.php
+++ b/tests/Feature/DefaultPageTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use Crumbls\Layup\Models\Page;
+
+beforeEach(function (): void {
+    config(['layup.frontend.enabled' => true]);
+});
+
+it('serves the configured default page when no slug is provided', function (): void {
+    Page::create([
+        'title' => 'Welcome Home',
+        'slug' => 'home',
+        'content' => ['rows' => [[
+            'id' => 'r1',
+            'settings' => [],
+            'columns' => [[
+                'id' => 'c1',
+                'span' => ['sm' => 12, 'md' => 12, 'lg' => 12, 'xl' => 12],
+                'settings' => [],
+                'widgets' => [[
+                    'id' => 'w1',
+                    'type' => 'text',
+                    'data' => ['content' => '<p>Welcome to our site</p>'],
+                ]],
+            ]],
+        ]]],
+        'status' => 'published',
+    ]);
+
+    config(['layup.pages.default_slug' => 'home']);
+
+    $this->get('/')
+        ->assertStatus(200)
+        ->assertSee('Welcome to our site');
+});
+
+it('falls back to empty slug when default_slug is null', function (): void {
+    Page::create([
+        'title' => 'Root Page',
+        'slug' => '',
+        'content' => ['rows' => [[
+            'id' => 'r1',
+            'settings' => [],
+            'columns' => [[
+                'id' => 'c1',
+                'span' => ['sm' => 12, 'md' => 12, 'lg' => 12, 'xl' => 12],
+                'settings' => [],
+                'widgets' => [[
+                    'id' => 'w1',
+                    'type' => 'text',
+                    'data' => ['content' => '<p>Root content</p>'],
+                ]],
+            ]],
+        ]]],
+        'status' => 'published',
+    ]);
+
+    config(['layup.pages.default_slug' => null]);
+
+    $this->get('/')
+        ->assertStatus(200)
+        ->assertSee('Root content');
+});
+
+it('returns 404 when default page does not exist', function (): void {
+    config(['layup.pages.default_slug' => 'nonexistent-home']);
+
+    $this->get('/')->assertStatus(404);
+});
+
+it('returns 404 when default page is draft', function (): void {
+    Page::create([
+        'title' => 'Draft Home',
+        'slug' => 'home',
+        'content' => ['rows' => []],
+        'status' => 'draft',
+    ]);
+
+    config(['layup.pages.default_slug' => 'home']);
+
+    $this->get('/')->assertStatus(404);
+});
+
+it('ignores default_slug when an explicit slug is provided', function (): void {
+    Page::create([
+        'title' => 'Home',
+        'slug' => 'home',
+        'content' => ['rows' => [[
+            'id' => 'r1',
+            'settings' => [],
+            'columns' => [[
+                'id' => 'c1',
+                'span' => ['sm' => 12, 'md' => 12, 'lg' => 12, 'xl' => 12],
+                'settings' => [],
+                'widgets' => [[
+                    'id' => 'w1',
+                    'type' => 'text',
+                    'data' => ['content' => '<p>Home page</p>'],
+                ]],
+            ]],
+        ]]],
+        'status' => 'published',
+    ]);
+
+    Page::create([
+        'title' => 'About Us',
+        'slug' => 'about',
+        'content' => ['rows' => [[
+            'id' => 'r1',
+            'settings' => [],
+            'columns' => [[
+                'id' => 'c1',
+                'span' => ['sm' => 12, 'md' => 12, 'lg' => 12, 'xl' => 12],
+                'settings' => [],
+                'widgets' => [[
+                    'id' => 'w1',
+                    'type' => 'text',
+                    'data' => ['content' => '<p>About us content</p>'],
+                ]],
+            ]],
+        ]]],
+        'status' => 'published',
+    ]);
+
+    config(['layup.pages.default_slug' => 'home']);
+
+    $this->get('/about')
+        ->assertStatus(200)
+        ->assertSee('About us content')
+        ->assertDontSee('Home page');
+});
+
+it('returns 404 at index when no default is configured and no empty-slug page exists', function (): void {
+    config(['layup.pages.default_slug' => null]);
+
+    $this->get('/')->assertStatus(404);
+});

--- a/tests/Feature/PageControllerTest.php
+++ b/tests/Feature/PageControllerTest.php
@@ -7,6 +7,9 @@ use Crumbls\Layup\Models\Page;
 beforeEach(function (): void {
     config(['layup.frontend.enabled' => true]);
     config(['layup.frontend.include_scripts' => true]);
+
+    $prefix = config('layup.frontend.prefix', 'pages');
+    $this->routePrefix = $prefix !== '' ? "/{$prefix}" : '';
 });
 
 it('returns 200 for a published page', function (): void {
@@ -17,11 +20,11 @@ it('returns 200 for a published page', function (): void {
         'status' => 'published',
     ]);
 
-    $this->get('/pages/test-page')->assertStatus(200);
+    $this->get("{$this->routePrefix}/test-page")->assertStatus(200);
 });
 
 it('returns 404 for a missing slug', function (): void {
-    $this->get('/pages/nonexistent')->assertStatus(404);
+    $this->get("{$this->routePrefix}/nonexistent")->assertStatus(404);
 });
 
 it('returns 404 for a draft page', function (): void {
@@ -32,7 +35,7 @@ it('returns 404 for a draft page', function (): void {
         'status' => 'draft',
     ]);
 
-    $this->get('/pages/draft-page')->assertStatus(404);
+    $this->get("{$this->routePrefix}/draft-page")->assertStatus(404);
 });
 
 it('supports nested slugs', function (): void {
@@ -43,7 +46,7 @@ it('supports nested slugs', function (): void {
         'status' => 'published',
     ]);
 
-    $this->get('/pages/about/team')->assertStatus(200);
+    $this->get("{$this->routePrefix}/about/team")->assertStatus(200);
 });
 
 it('renders widget HTML for text widget', function (): void {
@@ -67,7 +70,7 @@ it('renders widget HTML for text widget', function (): void {
         'status' => 'published',
     ]);
 
-    $this->get('/pages/text-test')
+    $this->get("{$this->routePrefix}/text-test")
         ->assertStatus(200)
         ->assertSee('Hello from Layup');
 });
@@ -93,7 +96,7 @@ it('renders heading widget with correct level', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/heading-test');
+    $response = $this->get("{$this->routePrefix}/heading-test");
     $response->assertStatus(200);
     $response->assertSee('Big Title');
     $response->assertSee('<h1', false);
@@ -120,7 +123,7 @@ it('renders button widget', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/button-test');
+    $response = $this->get("{$this->routePrefix}/button-test");
     $response->assertStatus(200);
     $response->assertSee('Click Me');
     $response->assertSee('https://example.com', false);
@@ -147,7 +150,7 @@ it('renders accordion widget with Alpine directive', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/accordion-test');
+    $response = $this->get("{$this->routePrefix}/accordion-test");
     $response->assertStatus(200);
     $response->assertSee('layupAccordion', false);
     $response->assertSee('Q1');
@@ -184,7 +187,7 @@ it('renders pricing table with featured badge', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/pricing-test');
+    $response = $this->get("{$this->routePrefix}/pricing-test");
     $response->assertStatus(200);
     $response->assertSee('Pro Plan');
     $response->assertSee('Popular');
@@ -213,7 +216,7 @@ it('renders countdown widget with Alpine directive', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/countdown-test');
+    $response = $this->get("{$this->routePrefix}/countdown-test");
     $response->assertStatus(200);
     $response->assertSee('layupCountdown', false);
     $response->assertSee('Launch!');
@@ -236,7 +239,7 @@ it('renders row with container class', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/container-test');
+    $response = $this->get("{$this->routePrefix}/container-test");
     $response->assertStatus(200);
     $response->assertSee('container', false);
     $response->assertSee('mx-auto', false);
@@ -259,7 +262,7 @@ it('renders full-width row without container', function (): void {
         'status' => 'published',
     ]);
 
-    $content = $this->get('/pages/full-width-test')->getContent();
+    $content = $this->get("{$this->routePrefix}/full-width-test")->getContent();
     // The inner flex div should NOT have container class
     expect($content)->toContain('flex flex-wrap');
     // full_width rows skip the container — check the flex div doesn't include it
@@ -284,7 +287,7 @@ it('renders column with correct responsive width classes', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/col-width-test');
+    $response = $this->get("{$this->routePrefix}/col-width-test");
     $response->assertStatus(200);
     $response->assertSee('w-full', false);
     $response->assertSee('md:w-6/12', false);
@@ -308,7 +311,7 @@ it('renders column gutters correctly for multi-column rows', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/gutter-test');
+    $response = $this->get("{$this->routePrefix}/gutter-test");
     $content = $response->getContent();
     $response->assertStatus(200);
     expect($content)->toContain('md:pr-2');
@@ -324,7 +327,7 @@ it('includes @layupScripts when enabled', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/scripts-test');
+    $response = $this->get("{$this->routePrefix}/scripts-test");
     $response->assertStatus(200);
     $response->assertSee('alpine:init', false);
     $response->assertSee('Alpine.data', false);
@@ -340,12 +343,11 @@ it('excludes @layupScripts when disabled', function (): void {
         'status' => 'published',
     ]);
 
-    $content = $this->get('/pages/no-scripts')->getContent();
+    $content = $this->get("{$this->routePrefix}/no-scripts")->getContent();
     expect($content)->not->toContain('Alpine.data');
 });
 
 it('uses configurable route prefix', function (): void {
-    // Default prefix is 'pages'
     Page::create([
         'title' => 'Prefix Test',
         'slug' => 'prefix-test',
@@ -353,7 +355,7 @@ it('uses configurable route prefix', function (): void {
         'status' => 'published',
     ]);
 
-    $this->get('/pages/prefix-test')->assertStatus(200);
+    $this->get("{$this->routePrefix}/prefix-test")->assertStatus(200);
 });
 
 it('renders multiple widgets in a single column', function (): void {
@@ -377,7 +379,7 @@ it('renders multiple widgets in a single column', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/multi-widget');
+    $response = $this->get("{$this->routePrefix}/multi-widget");
     $response->assertStatus(200);
     $response->assertSee('Title Here');
     $response->assertSee('Body text');
@@ -404,7 +406,7 @@ it('renders spacer and divider widgets', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/layout-widgets');
+    $response = $this->get("{$this->routePrefix}/layout-widgets");
     $response->assertStatus(200);
     $response->assertSee('3rem', false);
     $response->assertSee('dashed', false);
@@ -436,7 +438,7 @@ it('skips unknown widget types gracefully', function (): void {
         'status' => 'published',
     ]);
 
-    $response = $this->get('/pages/unknown-widget');
+    $response = $this->get("{$this->routePrefix}/unknown-widget");
     $response->assertStatus(200);
     $response->assertSee('Still works');
 });

--- a/tests/Unit/PageModelTest.php
+++ b/tests/Unit/PageModelTest.php
@@ -94,7 +94,9 @@ it('reads table name from config', function (): void {
 
 it('getUrl() returns the correct URL', function (): void {
     $page = Page::create(['title' => 'Url', 'slug' => 'my-page', 'status' => 'draft']);
-    expect($page->getUrl())->toEndWith('/pages/my-page');
+    $prefix = config('layup.frontend.prefix', 'pages');
+    $expected = ltrim("{$prefix}/my-page", '/');
+    expect($page->getUrl())->toEndWith("/{$expected}");
 });
 
 it('getMetaTitle() falls back to title', function (): void {
@@ -217,13 +219,13 @@ it('prunes old revisions beyond max', function (): void {
 });
 
 it('sitemapEntries returns published pages', function (): void {
-    Page::create(['title' => 'Published', 'slug' => 'sitemap-pub', 'content' => ['rows' => []], 'status' => 'published']);
+    $pub = Page::create(['title' => 'Published', 'slug' => 'sitemap-pub', 'content' => ['rows' => []], 'status' => 'published']);
     Page::create(['title' => 'Draft', 'slug' => 'sitemap-draft', 'content' => ['rows' => []], 'status' => 'draft']);
 
     $entries = Page::sitemapEntries();
     $urls = array_column($entries, 'url');
-    expect($urls)->toContain(url('pages/sitemap-pub'));
-    expect($urls)->not->toContain(url('pages/sitemap-draft'));
+    expect($urls)->toContain($pub->getUrl());
+    expect($urls)->not->toContain(url('sitemap-draft'));
 });
 
 it('does not sync safelist when auto_sync is disabled', function (): void {


### PR DESCRIPTION
 New `pages.default_slug` config key lets users designate any page as the homepage without creating a page with an empty slug
   - When the index route is hit (`/pages` or `/` with empty prefix), the controller falls back to the configured slug
   - Setting `default_slug` to `null` preserves existing behavior
   - Updated README with Default Page section and config reference
   - Fixed all existing tests to build URLs from config prefix instead of hardcoding `/pages`
   - Added 6 new tests covering default page resolution, fallback, draft handling, and explicit slug precedence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `pages.default_slug` configuration option to control which page is served at the root path. Setting this to `null` restores the previous behavior of serving the empty-slug page.

* **Documentation**
  * Added documentation for the new configuration option with examples for prefixed and non-prefixed routing setups.

* **Tests**
  * Added comprehensive tests for default page routing and updated existing tests to support configurable path prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->