### PR TITLE
docs: clarify frontend prefix semantics and layouts:: namespace

### DIFF
--- a/config/layup.php
+++ b/config/layup.php
@@ -190,13 +190,30 @@ return [
     */
     'frontend' => [
         'enabled' => true,
+
+        // URL prefix. Use '' or '/' to mount at the site root — these are the
+        // only values that activate auto-exclusion of Filament panel paths and
+        // framework routes. Other values (including null) are treated as a
+        // literal prefix with no auto-exclusion.
         'prefix' => 'pages',
+
         'middleware' => ['web'],
         'domain' => null,
+
+        // Blade component name passed to <x-dynamic-component>. Examples:
+        //   'app'          -> resources/views/components/app.blade.php
+        //   'layouts.app'  -> resources/views/components/layouts/app.blade.php
+        //   'layouts::app' -> resources/views/layouts/app.blade.php
+        //                    (Livewire anonymous namespace — use this with
+        //                    the Livewire starter kit)
         'layout' => 'app',
+
         'view' => 'layup::frontend.page',
         'max_width' => 'container',
         'include_scripts' => true,
+
+        // Additional paths to exclude from the root-mount catch-all.
+        // Only applied when 'prefix' is '' or '/'.
         'excluded_paths' => [],
     ],
 

--- a/docs/advanced/frontend-rendering.md
+++ b/docs/advanced/frontend-rendering.md
@@ -11,6 +11,9 @@ The `layout` config value is a Blade component name passed to `<x-dynamic-compon
 
 - `'app'` resolves to `resources/views/components/app.blade.php`
 - `'layouts.app'` resolves to `resources/views/components/layouts/app.blade.php`
+- `'layouts::app'` resolves to `resources/views/layouts/app.blade.php` (Livewire anonymous namespace)
+
+> **Using the Livewire starter kit?** Livewire v4 registers `layouts` as an anonymous component namespace pointing at `resources/views/layouts/`, and the starter kit ships its layout at `resources/views/layouts/app.blade.php`. Set `'layout' => 'layouts::app'` — the dot-notation form (`'layouts.app'`) resolves to a different path that does not exist in Livewire starter-kit projects.
 
 Your layout must accept a `title` slot and optionally a `meta` slot:
 
@@ -55,6 +58,8 @@ Layup automatically excludes Filament panel paths, Livewire, and other framework
     'excluded_paths' => ['blog', 'shop'],
 ],
 ```
+
+> **`prefix` values:** use `''` or `'/'` to mount at the site root — these are the only values that activate the Filament / framework path auto-exclusion. Any other string (e.g. `'pages'`) becomes a literal URL prefix. Setting `prefix` to `null` skips the auto-exclusion logic, so the `{slug}` catch-all can shadow unmatched admin URLs (for example, a Filament resource that has not been created yet). Prefer `''` over `null` when running at the root.
 
 ## Nested slugs
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,14 +87,17 @@ The filesystem disk used for media uploads (images, files). Must be publicly acc
 ```
 
 - **enabled** -- register frontend routes for serving published pages
-- **prefix** -- URL prefix (e.g., `pages` makes URLs like `/pages/about`)
+- **prefix** -- URL prefix. Use `'pages'` for `/pages/about`, or `''` (or `'/'`) to mount at the site root. An empty/slash prefix activates auto-exclusion of Filament panel paths, Livewire, and other framework routes; other values (including `null`) skip that safeguard. See [Frontend Rendering > Serving pages at the site root](advanced/frontend-rendering.md#serving-pages-at-the-site-root).
 - **middleware** -- middleware applied to frontend routes
 - **domain** -- restrict routes to a specific domain
-- **layout** -- Blade component used as the page layout (e.g., `app` for `<x-app>`)
+- **layout** -- Blade component name passed to `<x-dynamic-component>`. Example values:
+    - `'app'` → `resources/views/components/app.blade.php`
+    - `'layouts.app'` → `resources/views/components/layouts/app.blade.php`
+    - `'layouts::app'` → `resources/views/layouts/app.blade.php` (Livewire anonymous namespace — use this with the Livewire starter kit)
 - **view** -- Blade view for rendering pages
 - **max_width** -- CSS class for page container width
 - **include_scripts** -- include Alpine.js animation scripts in frontend
-- **excluded_paths** -- slug patterns to exclude from Layup routing
+- **excluded_paths** -- additional paths to exclude from the root-mount catch-all (only applied when `prefix` is `''` or `'/'`)
 
 ## Safelist
 


### PR DESCRIPTION
## Summary

Docs-only PR. Two gotchas first-time installers hit when wiring Layup into a project that uses the Livewire starter kit alongside a Filament admin panel:

1. **`layout` config** — The Livewire starter kit ships its layout at `resources/views/layouts/app.blade.php`, addressable via Livewire v4's `layouts::` anonymous component namespace. The existing docs only showed the Blade dot-notation form (`'layouts.app'`), which resolves to `resources/views/components/layouts/app.blade.php` — a path that does not exist in starter-kit projects. Users pattern-match to `'layouts.app'` and get a "component not found" error.

2. **`prefix` config** — The auto-exclusion of Filament panel paths in `routes/web.php` only fires when `$prefix === '' || $prefix === '/'`. Any other value (including `null`, which a user may reach for by analogy with `domain: null`) skips that safeguard, and the `{slug}` catch-all then shadows unmatched Filament admin URLs (e.g. a resource route that doesn't exist yet, or any non-Filament panel action).

## Changes

- `config/layup.php` — inline comments on `prefix`, `layout`, and `excluded_paths`
- `docs/configuration.md` — Frontend section now lists the three layout resolution forms and calls out the prefix / auto-exclusion coupling
- `docs/advanced/frontend-rendering.md` — adds a Livewire starter-kit callout under "Layout requirements" and a prefix-semantics callout under "Serving pages at the site root"

## Out of scope (flagged for a follow-up if you want)

Docs are the least invasive fix, but the underlying `null`-vs-`''` footgun could also be closed in code. Options:

- Treat `null` the same as `''` in the exclusion check: `if ($prefix === '' || $prefix === '/' || $prefix === null)`
- Or skip `loadRoutesFrom` when `prefix` is `null` and document `null` as "routes disabled"

Happy to open a separate PR for whichever you prefer.

## Test plan

- [x] Docs render correctly on the documentation site
- [x] Inline config comments survive `php artisan vendor:publish --tag=layup-config`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `excluded_paths` configuration option to exclude additional paths from root-mount routing.

* **Documentation**
  * Clarified `prefix` configuration behavior for site-root mounting.
  * Updated `layout` configuration documentation with component resolution examples.
  * Added setup guidance for Livewire starter kit projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->