### PR TITLE
refactor: use Storage facade for import file handling

### DIFF
--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -30,6 +30,7 @@ return [
 
     // Import
     'file_not_found' => 'Datei nicht gefunden',
+    'file_delete_failed' => 'Importiert, aber die temporäre Datei konnte nicht gelöscht werden',
     'invalid_json' => 'Ungültige Layup-JSON-Datei',
     'invalid_content_structure' => 'Ungültige Seiteninhalt-Struktur',
     'page_imported' => 'Seite erfolgreich importiert',

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -30,6 +30,7 @@ return [
 
     // Import
     'file_not_found' => 'File not found',
+    'file_delete_failed' => 'Imported but could not remove the temporary file',
     'invalid_json' => 'Invalid Layup JSON file',
     'invalid_content_structure' => 'Invalid page content structure',
     'page_imported' => 'Page imported successfully',

--- a/src/Resources/PageResource/Pages/ListPages.php
+++ b/src/Resources/PageResource/Pages/ListPages.php
@@ -136,14 +136,36 @@ class ListPages extends ListRecords
                 ])
                 ->action(function (array $data): void {
                     $disk = config('filament.default_filesystem_disk', 'public');
-                    if (! Storage::disk($disk)->exists($data['file'])) {
+                    $diskInstance = Storage::disk($disk);
+                    $file = $data['file'];
+
+                    if (! $diskInstance->exists($file)) {
                         Notification::make()->danger()->title(__('layup::notifications.file_not_found'))->send();
 
                         return;
                     }
 
-                    $json = json_decode(Storage::disk($disk)->get($data['file']), true);
-                    Storage::disk($disk)->delete($data['file']);
+                    $contents = null;
+
+                    try {
+                        $contents = $diskInstance->get($file);
+
+                        if ($contents === null) {
+                            Notification::make()->danger()->title(__('layup::notifications.file_not_found'))->send();
+
+                            return;
+                        }
+
+                        if (! $diskInstance->delete($file)) {
+                            Notification::make()->warning()->title(__('layup::notifications.file_delete_failed'))->send();
+                        }
+                    } catch (\Throwable $e) {
+                        Notification::make()->danger()->title(__('layup::notifications.file_not_found'))->send();
+
+                        return;
+                    }
+
+                    $json = json_decode($contents, true);
 
                     if (! $json || ! isset($json['content'])) {
                         Notification::make()->danger()->title(__('layup::notifications.invalid_json'))->send();

--- a/src/Resources/PageResource/Pages/ListPages.php
+++ b/src/Resources/PageResource/Pages/ListPages.php
@@ -17,6 +17,7 @@ use Filament\Resources\Pages\ListRecords;
 use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Components\Utilities\Set;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class ListPages extends ListRecords
@@ -134,16 +135,15 @@ class ListPages extends ListRecords
                         ->required(),
                 ])
                 ->action(function (array $data): void {
-                    $path = \Storage::path($data['file']);
-
-                    if (! file_exists($path)) {
+                    $disk = config('filament.default_filesystem_disk', 'public');
+                    if (! Storage::disk($disk)->exists($data['file'])) {
                         Notification::make()->danger()->title(__('layup::notifications.file_not_found'))->send();
 
                         return;
                     }
 
-                    $json = json_decode(file_get_contents($path), true);
-                    @unlink($path);
+                    $json = json_decode(Storage::disk($disk)->get($data['file']), true);
+                    Storage::disk($disk)->delete($data['file']);
 
                     if (! $json || ! isset($json['content'])) {
                         Notification::make()->danger()->title(__('layup::notifications.invalid_json'))->send();


### PR DESCRIPTION
Expands on #43 by importing the Storage facade properly and replacing native PHP file functions with consistent Storage::disk() calls. Resolves disk ambiguity by reading filament.default_filesystem_disk so the upload and storage operations always target the same disk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved page import handling to reliably read uploaded JSON from configured storage, better validate contents, and surface success or error notifications.
* **Bug Fixes**
  * Added checks and notifications when uploaded files are missing, empty, or cannot be removed after import.
* **Documentation**
  * Added English and German notification text for failed temporary file deletion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Crumbls/layup/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->