### PR TITLE
Add scope for published posts. Make publishing easier in admin.

### DIFF
--- a/resources/lang/de/resource.php
+++ b/resources/lang/de/resource.php
@@ -67,6 +67,8 @@ return [
     'featured_image' => 'Beitragsbild',
     'featured_image_help' => 'Wird für Social Shares (OG/Twitter), Schema und Theme-Vorschaubilder verwendet.',
     'permalink' => 'Permalink',
+    'draft_not_published' => 'Entwurf — noch nicht veröffentlicht',
+    'scheduled_for' => 'Geplant für :time',
     'empty_trash' => 'Papierkorb leeren',
     'empty_trash_confirm_heading' => 'Alle Seiten im Papierkorb dauerhaft löschen?',
     'empty_trash_confirm_description' => 'Dies löscht alle Seiten im Papierkorb endgültig. Diese Aktion kann nicht rückgängig gemacht werden.',
@@ -75,6 +77,8 @@ return [
     // Bearbeitungsseite Kopfaktionen
     'page_settings' => 'Seiteneinstellungen',
     'page_settings_updated' => 'Seiteneinstellungen aktualisiert',
+    'page_published' => 'Seite veröffentlicht',
+    'page_unpublished' => 'Seite als Entwurf gespeichert',
     'revision_history' => 'Versionsgeschichte',
     'revision_history_description' => 'Frühere Versionen dieser Seite anzeigen und wiederherstellen',
     'save_as_template' => 'Als Vorlage speichern',

--- a/resources/lang/en/resource.php
+++ b/resources/lang/en/resource.php
@@ -67,6 +67,8 @@ return [
     'featured_image' => 'Featured Image',
     'featured_image_help' => 'Used for social shares (OG/Twitter), schema, and theme thumbnails.',
     'permalink' => 'Permalink',
+    'draft_not_published' => 'Draft — not published yet',
+    'scheduled_for' => 'Scheduled for :time',
     'empty_trash' => 'Empty Trash',
     'empty_trash_confirm_heading' => 'Permanently delete every page in trash?',
     'empty_trash_confirm_description' => 'This force-deletes all trashed pages. This action cannot be undone.',
@@ -75,6 +77,8 @@ return [
     // Edit page header actions
     'page_settings' => 'Page Settings',
     'page_settings_updated' => 'Page settings updated',
+    'page_published' => 'Page published',
+    'page_unpublished' => 'Page moved to draft',
     'revision_history' => 'Revision History',
     'revision_history_description' => 'View and restore previous versions of this page',
     'save_as_template' => 'Save as Template',

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -443,6 +443,19 @@ class Page extends Model
     }
 
     /**
+     * Whether this page is live: published status and either no publish
+     * date or a date that has already passed.
+     */
+    public function isPublished(): bool
+    {
+        if ($this->status !== self::STATUS_PUBLISHED) {
+            return false;
+        }
+
+        return $this->published_at === null || $this->published_at <= now();
+    }
+
+    /**
      * Get the public-facing URL for this page.
      */
     public function getUrl(): string

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -95,14 +95,18 @@ class PageResource extends Resource
     }
 
     /**
-     * Render the live permalink preview shown above the builder. Path
-     * stays muted, slug segment is bold so the user sees what they're
-     * editing in the Page Settings modal.
+     * Render the status indicator shown above the builder. Draft and
+     * scheduled pages show a muted "not published" pill instead of a
+     * live link, since the URL only resolves once the page is published.
      */
     protected static function renderPermalink(?Model $record): HtmlString
     {
         if (! $record || ! $record->path) {
             return new HtmlString('');
+        }
+
+        if (! $record->isPublished()) {
+            return self::renderUnpublishedPill($record);
         }
 
         $url = $record->getUrl();
@@ -126,6 +130,31 @@ class PageResource extends Resource
             . '<span>' . $baseHtml . '</span>'
             . '<span class="font-semibold text-gray-900 dark:text-gray-100">' . $slugHtml . '</span>'
             . '</a>'
+        );
+    }
+
+    /**
+     * Pill shown for draft / scheduled pages in place of the permalink.
+     * Scheduled pages surface their go-live time so the editor knows the
+     * page is queued rather than simply unpublished.
+     */
+    protected static function renderUnpublishedPill(Model $record): HtmlString
+    {
+        if ($record->status === Page::STATUS_SCHEDULED && $record->published_at) {
+            $label = __('layup::resource.scheduled_for', [
+                'time' => $record->published_at->isoFormat('lll'),
+            ]);
+            $classes = 'bg-info-50 text-info-700 dark:bg-info-400/10 dark:text-info-400';
+        } else {
+            $label = __('layup::resource.draft_not_published');
+            $classes = 'bg-gray-100 text-gray-600 dark:bg-white/5 dark:text-gray-400';
+        }
+
+        return new HtmlString(
+            '<span class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium ' . $classes . '">'
+            . '<span class="h-1.5 w-1.5 rounded-full bg-current opacity-70"></span>'
+            . e($label)
+            . '</span>'
         );
     }
 

--- a/src/Resources/PageResource/Pages/EditPage.php
+++ b/src/Resources/PageResource/Pages/EditPage.php
@@ -49,6 +49,39 @@ class EditPage extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('publish')
+                ->label(__('layup::resource.publish'))
+                ->icon('heroicon-o-rocket-launch')
+                ->color('success')
+                ->visible(fn (): bool => ! $this->record->isPublished())
+                ->action(function (): void {
+                    $this->record->update([
+                        'status' => Page::STATUS_PUBLISHED,
+                        'published_at' => null,
+                    ]);
+
+                    Notification::make()
+                        ->success()
+                        ->title(__('layup::resource.page_published'))
+                        ->send();
+                }),
+            Action::make('unpublish')
+                ->label(__('layup::resource.unpublish'))
+                ->icon('heroicon-o-eye-slash')
+                ->color('gray')
+                ->requiresConfirmation()
+                ->visible(fn (): bool => $this->record->isPublished())
+                ->action(function (): void {
+                    $this->record->update([
+                        'status' => Page::STATUS_DRAFT,
+                        'published_at' => null,
+                    ]);
+
+                    Notification::make()
+                        ->success()
+                        ->title(__('layup::resource.page_unpublished'))
+                        ->send();
+                }),
             Action::make('pageSettings')
                 ->label(__('layup::resource.page_settings'))
                 ->icon('heroicon-o-cog-6-tooth')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added page publish and unpublish actions in the editor header.
  * Draft and scheduled pages now show a clear status indicator instead of a live permalink preview.
  * Added new labels for published, unpublished, draft, and scheduled states in English and German.

* **Bug Fixes**
  * Improved publication-state handling so pages only appear published when their status and scheduled time allow it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->